### PR TITLE
Build docs scripts

### DIFF
--- a/.packer/win/scripts/vcpkg.ps1
+++ b/.packer/win/scripts/vcpkg.ps1
@@ -3,17 +3,20 @@ $ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';
 echo "Cloning and setting up vcpkg"
 git clone https://github.com/Microsoft/vcpkg.git C:\vcpkg
 
-echo "Run bootstrap-vcpkg.bat"
-C:\vcpkg\bootstrap-vcpkg.bat
-
-echo "Run vcpkg.exe integrate install"
-C:\vcpkg\vcpkg.exe integrate install
-
 echo "Checkout to commit"
 git -C C:\vcpkg checkout (Get-Content -Path c:\Windows\Temp\vcpkg\VCPKG_COMMIT_SHA)
 
 echo "Apply patches to vcpkg"
 foreach($file in Get-ChildItem c:\Windows\Temp\vcpkg\patches -Filter *.patch) { git -C C:\vcpkg apply $file.FullName }
 
+echo "Run bootstrap-vcpkg.bat"
+C:\vcpkg\bootstrap-vcpkg.bat
+
 echo "Installing vcpkg packages"
 C:\vcpkg\vcpkg.exe install (Get-Content -Path c:\Windows\Temp\vcpkg\VCPKG_DEPS_LIST).replace(":",":x64-windows")
+
+echo "Installing rx-cpp"
+C:\vcpkg\vcpkg.exe install (Get-Content -Path c:\Windows\Temp\vcpkg\VCPKG_HEAD_DEPS_LIST).replace(":",":x64-windows")
+
+echo "Run vcpkg.exe integrate install"
+C:\vcpkg\vcpkg.exe integrate install

--- a/docker/develop/Dockerfile
+++ b/docker/develop/Dockerfile
@@ -54,12 +54,7 @@ RUN set -e; \
 # install dependencies
 COPY vcpkg /tmp/vcpkg-vars
 RUN set -e; \
-    git clone https://github.com/microsoft/vcpkg /tmp/vcpkg; \
-    (cd /tmp/vcpkg ; git checkout $(cat /tmp/vcpkg-vars/VCPKG_COMMIT_SHA)); \
-    for i in /tmp/vcpkg-vars/patches/*.patch; do git -C /tmp/vcpkg apply $i; done; \
-    sh /tmp/vcpkg/bootstrap-vcpkg.sh; \
-    /tmp/vcpkg/vcpkg install $(cat /tmp/vcpkg-vars/VCPKG_DEPS_LIST | cut -d':' -f1 | tr '\n' ' '); \
-    /tmp/vcpkg/vcpkg install --head $(cat /tmp/vcpkg-vars/VCPKG_HEAD_DEPS_LIST | cut -d':' -f1 | tr '\n' ' '); \
+    sh /tmp/vcpkg-vars/build_iroha_deps.sh /tmp/vcpkg /tmp/vcpkg-vars; \
     /tmp/vcpkg/vcpkg export $(/tmp/vcpkg/vcpkg list | cut -d':' -f1 | tr '\n' ' ') --raw --output=dependencies; \
     mv /tmp/vcpkg/dependencies /opt/dependencies; \
     chmod +x /opt/dependencies/installed/x64-linux/tools/protobuf/protoc*; \

--- a/docs/source/guides/build.rst
+++ b/docs/source/guides/build.rst
@@ -171,14 +171,8 @@ Run in terminal:
 .. code-block:: shell
 
   git clone https://github.com/hyperledger/iroha.git
-  git clone https://github.com/Microsoft/vcpkg.git
-  cd vcpkg
-  git checkout $(cat ../iroha/vcpkg/VCPKG_COMMIT_SHA)
-  for i in ../iroha/vcpkg/patches/*.patch; do git apply $i; done;
-  ./bootstrap-vcpkg.sh
-  ./vcpkg install $(cat ../iroha/vcpkg/VCPKG_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')
-  ./vcpkg install --head $(cat ../iroha/vcpkg/VCPKG_HEAD_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')
-  ./vcpkg integrate install
+  iroha/vcpkg/build_iroha_deps.sh
+  vcpkg/vcpkg integrate install
 
 After the installation of vcpkg you will be provided with a CMake build parameter like
 ``-DCMAKE_TOOLCHAIN_FILE=/path/to/vcpkg/scripts/buildsystems/vcpkg.cmake``.

--- a/vcpkg/build_iroha_deps.sh
+++ b/vcpkg/build_iroha_deps.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -e
+
+if [ -z "$1" ]
+  then
+    vcpkg_path="$(pwd)/vcpkg"
+  else
+    vcpkg_path="$1"
+fi
+if [ -z "$2" ]
+  then
+    iroha_vcpkg_path="$(pwd)/iroha/vcpkg"
+  else
+    iroha_vcpkg_path="$2"
+fi
+
+git clone https://github.com/microsoft/vcpkg $vcpkg_path
+git -C $vcpkg_path checkout $(cat "$iroha_vcpkg_path"/VCPKG_COMMIT_SHA)
+for i in "$iroha_vcpkg_path"/patches/*.patch; do git -C $vcpkg_path apply $i; done;
+$vcpkg_path/bootstrap-vcpkg.sh
+$vcpkg_path/vcpkg install $(cat "$iroha_vcpkg_path"/VCPKG_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')
+$vcpkg_path/vcpkg install --head $(cat "$iroha_vcpkg_path"/VCPKG_HEAD_DEPS_LIST | cut -d':' -f1 | tr '\n' ' ')


### PR DESCRIPTION
### Description of the Change
Build scripts updated. They are necessary to properly update build process in docs. For Linux/Mac we now use the same script for docs and for Docker. For Windows we can't since it forbids running scripts by default.

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. -->
<!-- Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

### Benefits
No code duplication. Windows script was fixed as well.

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks 
None?

<!-- What are the possible side-effects or negative impacts of the code change? -->
<!-- If no drawbacks, explicitly mention this (write None) -->


### Alternate Designs
For Windows we could use solutions like described at https://tecadmin.net/powershell-running-scripts-is-disabled-system/ but I don't think it's a good idea to ask user for such movements.
